### PR TITLE
Terra negative coordinates

### DIFF
--- a/core/Terra.cs
+++ b/core/Terra.cs
@@ -11,12 +11,12 @@ public class Terra {
 
     public Position boundries{get; private set;}
 
-    public Terra (Position boundries, Node parent) {
+    public Terra (Position position, Position boundries, Node parent) {
         this.parent = parent;
 
         this.boundries = boundries;
 
-        octree = new Octree (boundries.GetMax());
+        octree = new Octree (position, boundries.GetMax());
 
         meshes = new Dictionary<string, MeshInstance> ();
     }
@@ -30,25 +30,22 @@ public class Terra {
                 int currentLayer = octree.layers;
                 OctreeNode currentNode = octree.mainNode;
 
+                Position pos = new Position(posX, posY, posZ);
+                int size = octree.size;
+
                 while (currentLayer > layer) {
 
-                    int nodePosX = (int) (posX / (currentLayer * 2));
-                    int nodePosY = (int) (posY / (currentLayer * 2));
-                    int nodePosZ = (int) (posZ / (currentLayer * 2));
+                    currentNode = currentNode.SelectChild(Convert.ToInt32(posX > currentNode.center.x), Convert.ToInt32(posY > currentNode.center.y), Convert.ToInt32(posZ > currentNode.center.z));
 
-                    currentLayer -= 1;
+                    if (!currentNode.Initialized)
+                        currentNode.Initialize ();
 
-                    OctreeNode childNode = null;
-                    
-                    while(childNode == null)
+                    if(currentNode == null)
                     {
-                        childNode = currentNode.SelectChild(Convert.ToInt32(nodePosX > 0), Convert.ToInt32(nodePosY > 0), Convert.ToInt32(nodePosZ > 0));
+                        return null;
                     }
 
-                    if (!childNode.Initialized)
-                        childNode.Initialize ();
-
-                    currentNode = childNode;
+                    currentLayer -= 1;                                        
                 }
 
                 if (!currentNode.Initialized)

--- a/core/Terra.cs
+++ b/core/Terra.cs
@@ -26,18 +26,25 @@ public class Terra {
     }
 
     public OctreeNode TraverseOctree (int posX, int posY, int posZ, int layer) {
-        if (CheckBoundries(posX, posY, posZ) && layer < octree.layers) {
-            lock(this){
+        if (layer < octree.layers) {
                 int currentLayer = octree.layers;
                 OctreeNode currentNode = octree.mainNode;
+
                 while (currentLayer > layer) {
+
                     int nodePosX = (int) (posX / (currentLayer * 2));
                     int nodePosY = (int) (posY / (currentLayer * 2));
                     int nodePosZ = (int) (posZ / (currentLayer * 2));
 
                     currentLayer -= 1;
-                    int nodePos = SelectChildOctant (nodePosX, nodePosY, nodePosZ);
-                    OctreeNode childNode = currentNode.children[nodePos & 1, (nodePos & 2) >> 1, (nodePos & 4) >> 2];
+
+                    OctreeNode childNode = null;
+                    
+                    while(childNode == null)
+                    {
+                        childNode = currentNode.SelectChild(Convert.ToInt32(nodePosX > 0), Convert.ToInt32(nodePosY > 0), Convert.ToInt32(nodePosZ > 0));
+                    }
+
                     if (!childNode.Initialized)
                         childNode.Initialize ();
 
@@ -48,22 +55,12 @@ public class Terra {
                     currentNode.Initialize ();
 
                 if (currentLayer == 0) {
-
-                    int pos = SelectChildOctant (posX, posY, posZ);
-                    OctreeNode childNode = currentNode.children[pos & 1, (pos & 2) >> 1, (pos & 4) >> 2];
-
-                    return childNode;
+                    currentNode = currentNode.SelectChild(Convert.ToInt32(posX > 0), Convert.ToInt32(posY > 0), Convert.ToInt32(posZ > 0));
                 }
 
                 return currentNode;
         }
-        }
         return null;
-    }
-
-    public bool CheckBoundries(int posX, int posY, int posZ){
-        return posX >= 0 && posY >= 0 && posZ >= 0 &&
-            posX <= boundries.x * 8 && posY <= boundries.y * 8 && posZ <= boundries.z * 8;
     }
 
     public void PlaceChunk (int posX, int posY, int posZ, Chunk chunk) {
@@ -77,10 +74,6 @@ public class Terra {
         OctreeNode node = octree.nodes[0][lolong];
         node.chunk = chunk;
         octree.nodes[0][lolong] = node;*/
-    }
-
-    private int SelectChildOctant (int posX, int posY, int posZ) {
-        return (posX % 2) * 4 | (posY % 2) * 2 | (posZ % 2);
     }
 
     private static MeshInstance DebugMesh () {

--- a/materials/Registry.cs
+++ b/materials/Registry.cs
@@ -38,6 +38,8 @@ public class Registry : List<TerraObject>
 
     public TerraObject SelectByID(int id)
     {
-        return this[id];
+        lock(this){
+            return this[id];
+        }
     }
 }

--- a/octrees/Chunk.cs
+++ b/octrees/Chunk.cs
@@ -1,9 +1,9 @@
 using System.Collections.Generic;
 public class Chunk
 {
-    public uint x { get; set; }
-    public uint y { get; set; }
-    public uint z { get; set; }
+    public int x { get; set; }
+    public int y { get; set; }
+    public int z { get; set; }
     public int Materials { get; set; }
     public List<Run> Voxels { get; set; }
     public bool IsEmpty { get; set; }

--- a/octrees/Octree.cs
+++ b/octrees/Octree.cs
@@ -1,16 +1,18 @@
 using System;
 public class Octree {
+    public Position center {get; set;}
     public int layers { get; set; }
     public int size { get; set; }
     public OctreeNode mainNode { get; set; }
 
-    public Octree (int size) {
+    public Octree (Position center, int size) {
+        this.center = center;
         this.size = size;
         // Calculate number of layers needed to represent the level
         layers = (int) Math.Log (Math.Pow (size, 3), 2);
 
         // Generate all the OctreeNodes
-        mainNode = new OctreeNode (size, layers);
+        mainNode = new OctreeNode (center, size, layers);
         mainNode.Initialize ();
     }
 }

--- a/octrees/OctreeNode.cs
+++ b/octrees/OctreeNode.cs
@@ -1,11 +1,12 @@
+using System.Collections.Concurrent;
 using System;
 using System.Numerics;
 public class OctreeNode {
-    const int DIM_LEN = 2;
+    const int DIM_LEN = 1;
     public Vector3 center { get; private set; }
     public int size { get; private set; }
     public bool Initialized { get; private set; }
-    public OctreeNode[, , ] children { get; private set; }
+    private ConcurrentDictionary<ValueTuple<int, int, int>, OctreeNode> children;
     public Chunk chunk { get; set; }
     public static int numNodes = 0;
     public static int numNodesInit = 0;
@@ -20,17 +21,20 @@ public class OctreeNode {
     }
 
     public void Initialize () {
-        children = new OctreeNode[2, 2, 2];
-        for (int i = 0; i < DIM_LEN; i++)
-            for (int j = 0; j < DIM_LEN; j++)
-                for (int k = 0; k < DIM_LEN; k++) {
-                    children[i, j, k] = new OctreeNode (size / 2, layer - 1);
+        children = new ConcurrentDictionary<(int, int, int), OctreeNode>();
+        for (int i = 0; i < DIM_LEN; i ++)
+            for (int j = 0; j < DIM_LEN; j ++)
+                for (int k = 0; k < DIM_LEN; k ++) {
+                    children.TryAdd(new ValueTuple<int, int, int>(-i, -j , -k), new OctreeNode (size / 2, layer - 1));
                 }
+
         Initialized = true;
         numNodesInit++;
     }
 
-    public OctreeNode SelectChild (float x, float y, float z) {
-        return children[Convert.ToInt32 (x > center.X), Convert.ToInt32 (y > center.Y), Convert.ToInt32 (z > center.Z)];
+    public OctreeNode SelectChild (int x, int y, int z) {
+        OctreeNode node = null;
+        children.TryGetValue( new ValueTuple<int, int, int>(x, y, z), out node);
+        return node;
     }
 }

--- a/octrees/OctreeNode.cs
+++ b/octrees/OctreeNode.cs
@@ -2,34 +2,34 @@ using System.Collections.Concurrent;
 using System;
 using System.Numerics;
 public class OctreeNode {
-    const int DIM_LEN = 1;
-    public Vector3 center { get; private set; }
+    public Position center { get; private set; }
     public int size { get; private set; }
     public bool Initialized { get; private set; }
     private ConcurrentDictionary<ValueTuple<int, int, int>, OctreeNode> children;
     public Chunk chunk { get; set; }
-    public static int numNodes = 0;
-    public static int numNodesInit = 0;
     public int layer { get; private set; }
 
-    public OctreeNode (int size, int layer) {
-        this.size = size;
+    public OctreeNode (Position center, int size, int layer) {
         this.center = center;
+        this.size = size;
         this.layer = layer;
         this.Initialized = false;
-        numNodes++;
+        children = new ConcurrentDictionary<(int, int, int), OctreeNode>();
     }
 
     public void Initialize () {
-        children = new ConcurrentDictionary<(int, int, int), OctreeNode>();
-        for (int i = 0; i < DIM_LEN; i ++)
-            for (int j = 0; j < DIM_LEN; j ++)
-                for (int k = 0; k < DIM_LEN; k ++) {
-                    children.TryAdd(new ValueTuple<int, int, int>(-i, -j , -k), new OctreeNode (size / 2, layer - 1));
-                }
+        int size = this.size/2;
+        children.TryAdd(new ValueTuple<int, int, int>(1, 1 , 1), new OctreeNode (new Position(center.x + size, center.y + size, center.z + size), size, layer - 1));
+        children.TryAdd(new ValueTuple<int, int, int>(0, 1 , 1), new OctreeNode (new Position(center.x - size, center.y + size, center.z + size), size, layer - 1));
+        children.TryAdd(new ValueTuple<int, int, int>(1, 0 , 1), new OctreeNode (new Position(center.x + size, center.y - size, center.z + size), size, layer - 1));
+        children.TryAdd(new ValueTuple<int, int, int>(0, 0, 1), new OctreeNode (new Position(center.x - size, center.y - size, center.z + size), size,layer - 1));
+
+        children.TryAdd(new ValueTuple<int, int, int>(1, 1 , 0), new OctreeNode (new Position(center.x + size, center.y + size, center.z - size), size, layer - 1));
+        children.TryAdd(new ValueTuple<int, int, int>(0, 1 , 0), new OctreeNode (new Position(center.x - size, center.y + size, center.z - size), size, layer - 1));
+        children.TryAdd(new ValueTuple<int, int, int>(1, 0, 0), new OctreeNode (new Position(center.x + size, center.y - size, center.z - size), size, layer - 1));
+        children.TryAdd(new ValueTuple<int, int, int>(0, 0, 0), new OctreeNode (new Position(center.x - size, center.y - size, center.z - size), size, layer - 1));
 
         Initialized = true;
-        numNodesInit++;
     }
 
     public OctreeNode SelectChild (int x, int y, int z) {


### PR DESCRIPTION
Changes allow Terra to place chunks in negative coordinates and I also made the searching thread safe so it should be faster now. This required deleting bitwise operations but as I found out, they were implemented so badly that they only slowed down the code. Overall terra should be faster now and able to generate chunks anywhere.

This should solve this issues:
https://github.com/starandserpent/Terra/issues/8
https://github.com/starandserpent/Terra/issues/15